### PR TITLE
P2P.WebRTCのWebGLのスティッキーセッション有効化方法のガイド追記

### DIFF
--- a/docs/integration/p2p.webrtc.md
+++ b/docs/integration/p2p.webrtc.md
@@ -508,6 +508,10 @@ namespace Extreal.Integration.P2P.WebRTC.MVS.ClientControl
 
 ### シグナリングサーバーを冗長化する
 
+シグナリングサーバーには[Socket.IO](https://socket.io/)を利用しています。
+Socket.IOサーバーを複数にして冗長化する場合はスティッキーセッションが推奨されています。
+詳細は[Using multiple nodes](https://socket.io/docs/v4/using-multiple-nodes/)を参照してください。
+
 WebGLで使う場合にスティッキーセッションを有効にするには、PeerClientの作成時に追加の設定が必要です。
 WebGLSocketOptionsを指定したWebGLPeerConfigを使用することで、スティッキーセッションを有効にすることが可能です。
 

--- a/docs/integration/p2p.webrtc.md
+++ b/docs/integration/p2p.webrtc.md
@@ -529,7 +529,3 @@ public class ClientControlScope : LifetimeScope
 :::info
 C#で使う場合は設定の必要はありません。
 :::
-
-:::caution
-サーバー側の設定については[Using multiple nodes](https://socket.io/docs/v4/using-multiple-nodes/)を参照してください。
-:::

--- a/docs/integration/p2p.webrtc.md
+++ b/docs/integration/p2p.webrtc.md
@@ -19,6 +19,7 @@ WebRTCを活用すると比較的容易にP2Pを実現できますが、P2Pの�
 - P2Pの状態をトリガーに処理を追加できます。
 - Native(C#)のP2Pにアプリケーション固有の処理を追加できます。
 - WebGL(JavaScript)のP2Pにアプリケーション固有の処理を追加できます。
+- シグナリングサーバーを冗長化できます。
 
 ## Architecture
 
@@ -505,7 +506,7 @@ namespace Extreal.Integration.P2P.WebRTC.MVS.ClientControl
 }
 ```
 
-### スティッキーセッションの有効化
+### シグナリングサーバーを冗長化する
 
 WebGLで使う場合にスティッキーセッションを有効にするには、PeerClientの作成時に追加の設定が必要です。
 WebGLSocketOptionsを指定したWebGLPeerConfigを使用することで、スティッキーセッションを有効にすることが可能です。

--- a/docs/integration/p2p.webrtc.md
+++ b/docs/integration/p2p.webrtc.md
@@ -31,6 +31,7 @@ classDiagram
     PeerClient <|-- NativePeerClient
     PeerClient <|-- WebGLPeerClient
     PeerClient ..> PeerConfig
+    PeerConfig <|-- WebGLPeerConfig
 
     class PeerClientProvider {
         +Provide(peerConfig)$ PeerClient
@@ -60,6 +61,10 @@ classDiagram
     }
     
     class WebGLPeerClient {
+    }
+
+    class WebGLPeerConfig {
+        +WebGLSocketOptions WebGLSocketOptions
     }
 ```
 
@@ -499,3 +504,32 @@ namespace Extreal.Integration.P2P.WebRTC.MVS.ClientControl
     }
 }
 ```
+
+### スティッキーセッションの有効化
+
+WebGLで使う場合にスティッキーセッションを有効にするには、PeerClientの作成時に追加の設定が必要です。
+WebGLSocketOptionsを指定したWebGLPeerConfigを使用することで、スティッキーセッションを有効にすることが可能です。
+
+```csharp
+public class ClientControlScope : LifetimeScope
+{
+    protected override void Configure(IContainerBuilder builder)
+    {
+        var peerConfig = new PeerConfig("http://127.0.0.1:3010");
+        var webGLPeerConfig = new WebGLPeerConfig(
+            peerConfig,
+            new WebGLSocketOptions(withCredentials: true)
+        );
+        var peerClient = PeerClientProvider.Provide(webGLPeerConfig);
+        builder.RegisterComponent(peerClient);
+    }
+}
+```
+
+:::info
+C#で使う場合は設定の必要はありません。
+:::
+
+:::caution
+サーバー側の設定については[Using multiple nodes](https://socket.io/docs/v4/using-multiple-nodes/)を参照してください。
+:::

--- a/docs/release/unreleased.md
+++ b/docs/release/unreleased.md
@@ -62,10 +62,11 @@ sidebar_position: 1
 
 ## Changes
 ### Extreal.Integration.P2P.WebRTC
+#### Added
+- シグナリングサーバーを冗長化できるようにスティッキーセッションを有効化する設定を追加しました。([Doc](../integration/p2p.webrtc.md), [PR](https://github.com/extreal-dev/Extreal.Integration.P2P.WebRTC/pull/13))
 #### Changed
 - PeerConnectionのCreate/Closeでエラーが発生しても処理を継続するように変更しました。([Doc](../integration/p2p.webrtc.md), [PR](https://github.com/extreal-dev/Extreal.Integration.P2P.WebRTC/pull/9))
 - P2Pの各クライアントを識別できるように、自身及び接続または切断したクライアントのIDを取得できるように変更しました。([Doc](../integration/p2p.webrtc.md), [PR](https://github.com/extreal-dev/Extreal.Integration.P2P.WebRTC/pull/10))
-- WebGLでスティッキーセッションを使用する設定ができるように変更しました。([Doc](../integration/p2p.webrtc.md), [PR](https://github.com/extreal-dev/Extreal.Integration.P2P.WebRTC/pull/13))
 
 ## Upgrade guide {#upgrade-guide}
 

--- a/docs/release/unreleased.md
+++ b/docs/release/unreleased.md
@@ -65,6 +65,7 @@ sidebar_position: 1
 #### Changed
 - PeerConnectionのCreate/Closeでエラーが発生しても処理を継続するように変更しました。([Doc](../integration/p2p.webrtc.md), [PR](https://github.com/extreal-dev/Extreal.Integration.P2P.WebRTC/pull/9))
 - P2Pの各クライアントを識別できるように、自身及び接続または切断したクライアントのIDを取得できるように変更しました。([Doc](../integration/p2p.webrtc.md), [PR](https://github.com/extreal-dev/Extreal.Integration.P2P.WebRTC/pull/10))
+- WebGLでスティッキーセッションを使用する設定ができるように変更しました。([Doc](../integration/p2p.webrtc.md), [PR](https://github.com/extreal-dev/Extreal.Integration.P2P.WebRTC/pull/13))
 
 ## Upgrade guide {#upgrade-guide}
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/integration/p2p.webrtc.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/integration/p2p.webrtc.md
@@ -508,6 +508,10 @@ namespace Extreal.Integration.P2P.WebRTC.MVS.ClientControl
 
 ### Make the signaling server redundant
 
+Socket.IO is used for the signaling server.
+Sticky sessions are recommended when using multiple Socket.IO servers for redundancy.
+See Using multiple nodes for details.
+
 To enable sticky sessions when used with WebGL, additional configuration is required when creating the PeerClient.
 It is possible to enable sticky sessions using WebGLSocketOptions.
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/integration/p2p.webrtc.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/integration/p2p.webrtc.md
@@ -529,7 +529,3 @@ public class ClientControlScope : LifetimeScope
 :::info
 When using with C#, no settings are necessary.
 :::
-
-:::caution
-Please refer to [Using multiple nodes](https://socket.io/docs/v4/using-multiple-nodes/) for server-side configuration.
-:::

--- a/i18n/en/docusaurus-plugin-content-docs/current/integration/p2p.webrtc.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/integration/p2p.webrtc.md
@@ -19,6 +19,7 @@ This module provides base P2P features for Native(C#) and WebGL(JavaScript).
 - You can add processing to trigger P2P state.
 - You can add application-specific processing to Native(C#) P2P.
 - You can add application-specific processing to WebGL(JavaScript) P2P
+- You can make signaling servers redundant.
 
 ## Architecture
 
@@ -505,7 +506,7 @@ namespace Extreal.Integration.P2P.WebRTC.MVS.ClientControl
 }
 ```
 
-### Enable sticky session
+### Make the signaling server redundant
 
 To enable sticky sessions when used with WebGL, additional configuration is required when creating the PeerClient.
 It is possible to enable sticky sessions using WebGLSocketOptions.

--- a/i18n/en/docusaurus-plugin-content-docs/current/integration/p2p.webrtc.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/integration/p2p.webrtc.md
@@ -508,9 +508,9 @@ namespace Extreal.Integration.P2P.WebRTC.MVS.ClientControl
 
 ### Make the signaling server redundant
 
-Socket.IO is used for the signaling server.
+[Socket.IO](https://socket.io/) is used for the signaling server.
 Sticky sessions are recommended when using multiple Socket.IO servers for redundancy.
-See Using multiple nodes for details.
+See [Using multiple nodes](https://socket.io/docs/v4/using-multiple-nodes/) for details.
 
 To enable sticky sessions when used with WebGL, additional configuration is required when creating the PeerClient.
 It is possible to enable sticky sessions using WebGLSocketOptions.

--- a/i18n/en/docusaurus-plugin-content-docs/current/integration/p2p.webrtc.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/integration/p2p.webrtc.md
@@ -31,6 +31,7 @@ classDiagram
     PeerClient <|-- NativePeerClient
     PeerClient <|-- WebGLPeerClient
     PeerClient ..> PeerConfig
+    PeerConfig <|-- WebGLPeerConfig
 
     class PeerClientProvider {
         +Provide(peerConfig)$ PeerClient
@@ -61,6 +62,10 @@ classDiagram
     }
     
     class WebGLPeerClient {
+    }
+
+    class WebGLPeerConfig {
+        +WebGLSocketOptions WebGLSocketOptions
     }
 ```
 
@@ -499,3 +504,32 @@ namespace Extreal.Integration.P2P.WebRTC.MVS.ClientControl
     }
 }
 ```
+
+### Enable sticky session
+
+To enable sticky sessions when used with WebGL, additional configuration is required when creating the PeerClient.
+It is possible to enable sticky sessions using WebGLSocketOptions.
+
+```csharp
+public class ClientControlScope : LifetimeScope
+{
+    protected override void Configure(IContainerBuilder builder)
+    {
+        var peerConfig = new PeerConfig("http://127.0.0.1:3010");
+        var webGLPeerConfig = new WebGLPeerConfig(
+            peerConfig,
+            new WebGLSocketOptions(withCredentials: true)
+        );
+        var peerClient = PeerClientProvider.Provide(webGLPeerConfig);
+        builder.RegisterComponent(peerClient);
+    }
+}
+```
+
+:::info
+When using with C#, no settings are necessary.
+:::
+
+:::caution
+Please refer to [Using multiple nodes](https://socket.io/docs/v4/using-multiple-nodes/) for server-side configuration.
+:::

--- a/i18n/en/docusaurus-plugin-content-docs/current/release/unreleased.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/release/unreleased.md
@@ -62,10 +62,11 @@ The following Unity versions have been tested.
 
 ## Changes
 ### Extreal.Integration.P2P.WebRTC
+#### Added
+- Added setting to enable sticky sessions to make signaling servers redundant. ([Doc](../integration/p2p.webrtc.md), [PR](https://github.com/extreal-dev/Extreal.Integration.P2P.WebRTC/pull/13))
 #### Changed
 - Changed to continue processing even if errors occur in Create/Close of PeerConnection. ([Doc](../integration/p2p.webrtc.md), [PR](https://github.com/extreal-dev/Extreal.Integration.P2P.WebRTC/pull/9))
 - Changed so that the ID of your own client and connected or disconnected clients can be obtained, so that each P2P client can be identified. ([Doc](../integration/p2p.webrtc.md), [PR](https://github.com/extreal-dev/Extreal.Integration.P2P.WebRTC/pull/10))
-- Changed so that it can be configured to use sticky sessions when used with WebGL. ([Doc](../integration/p2p.webrtc.md), [PR](https://github.com/extreal-dev/Extreal.Integration.P2P.WebRTC/pull/13))
 
 ## Upgrade guide {#upgrade-guide}
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/release/unreleased.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/release/unreleased.md
@@ -65,6 +65,7 @@ The following Unity versions have been tested.
 #### Changed
 - Changed to continue processing even if errors occur in Create/Close of PeerConnection. ([Doc](../integration/p2p.webrtc.md), [PR](https://github.com/extreal-dev/Extreal.Integration.P2P.WebRTC/pull/9))
 - Changed so that the ID of your own client and connected or disconnected clients can be obtained, so that each P2P client can be identified. ([Doc](../integration/p2p.webrtc.md), [PR](https://github.com/extreal-dev/Extreal.Integration.P2P.WebRTC/pull/10))
+- Changed so that it can be configured to use sticky sessions when used with WebGL. ([Doc](../integration/p2p.webrtc.md), [PR](https://github.com/extreal-dev/Extreal.Integration.P2P.WebRTC/pull/13))
 
 ## Upgrade guide {#upgrade-guide}
 


### PR DESCRIPTION
﻿# 何の変更を加えましたか？

- P2P.WebRTCのWebGLでスティッキーセッションを有効にする方法を追記しました。
  - [ライブラリのPR](https://github.com/extreal-dev/Extreal.Integration.P2P.WebRTC/pull/13)

# 何を確認しましたか?

- [x] 変更したページと影響がありそうなページをブラウザで確認しました
- [x] 日本語と英語のページが一致していることを確認しました
- [x] リンクや画像のファイルパスは拡張子付きの相対パスになっていることを確認しました
  - [Link docs by file paths](https://docusaurus.io/docs/next/versioning#link-docs-by-file-paths)
  - [Global or versioned collocated assets](https://docusaurus.io/docs/next/versioning#global-or-versioned-collocated-assets)(using per-version)

# レビュアーへのメッセージ

ライブラリのPR
- [WebGLのスティッキーセッションへの対応](https://github.com/extreal-dev/Extreal.Integration.P2P.WebRTC/pull/13)
