### PR TITLE
Vivox Developer Portal廃止に伴うガイドの更新

### DIFF
--- a/docs/integration/chat.vivox.md
+++ b/docs/integration/chat.vivox.md
@@ -23,13 +23,6 @@ Vivoxを知らない場合は[Learning](../learning/intro.md#chat)を参照し�
 このガイドはVivoxを知っている前提で説明しています。
 :::
 
-:::caution
-Vivoxは元々存在していた[Vivox Developer Portal](https://developer.vivox.com/)と2021年10月に登場した[Unity Gaming Services](https://unity.com/ja/solutions/gaming-services)で使用できます。
-現時点のVivoxラッパーは[Vivox Developer Portal](https://developer.vivox.com/)に対応しています。
-[Unity Gaming Services](https://unity.com/ja/solutions/gaming-services)には対応していません。
-今後[Unity Gaming Services](https://unity.com/ja/solutions/gaming-services)への対応を検討します。
-:::
-
 ## Specification
 
 Vivoxラッパーの仕様は次の通りです。
@@ -147,7 +140,7 @@ Vivoxラッパーは次のパッケージを使います。
 
 VivoxClientを初期化します。
 
-[Vivox Developer Portal](https://developer.vivox.com/)でクライアントからの接続先となるアプリケーションが作成されているものとします。
+[Unity Dashboard](https://dashboard.unity3d.com/vivox)でクライアントからの接続先となるアプリケーションが作成されているものとします。
 
 VivoxClientの初期化にはVivoxへの接続情報を保持するVivoxAppConfigが必要です。
 今回は一例としてScriptableObjectでVivoxへの接続情報を設定する方法を紹介します。

--- a/docs/integration/chat.vivox.md
+++ b/docs/integration/chat.vivox.md
@@ -140,7 +140,7 @@ Vivoxラッパーは次のパッケージを使います。
 
 VivoxClientを初期化します。
 
-[Unity Dashboard](https://dashboard.unity3d.com/vivox)でクライアントからの接続先となるアプリケーションが作成されているものとします。
+クライアントからの接続先となる、Vivoxがセットアップされたプロジェクトが[Unity Cloud](https://cloud.unity.com)で作成されているものとします。
 
 VivoxClientの初期化にはVivoxへの接続情報を保持するVivoxAppConfigが必要です。
 今回は一例としてScriptableObjectでVivoxへの接続情報を設定する方法を紹介します。

--- a/docs/learning/chat.vivox.md
+++ b/docs/learning/chat.vivox.md
@@ -17,8 +17,8 @@ Coreの学習を実施していない方はこの学習より先に[Coreの学�
 
 Vivoxラッパーがセットアップされた学習用のプロジェクトを使って、バーチャル空間でテキストチャットとボイスチャットをできるようにアプリケーションの実装を追加していきます。
 
-この学習を行うにはクライアントからの接続先となる[Unity Dashboard](https://dashboard.unity3d.com/vivox)のアプリケーションが必要です。
-以降のハンズオンを始める前に[Unity Dashboard](https://dashboard.unity3d.com/vivox)でアプリケーションを作成しておいてください。
+この学習を行うにはクライアントからの接続先となるプロジェクトが[Unity Cloud](https://cloud.unity.com)に必要です。
+以降のハンズオンを始める前に[Unity Cloud](https://cloud.unity.com)でVivoxがセットアップされたプロジェクトを作成しておいてください。
 
 ## Prepare project
 

--- a/docs/learning/chat.vivox.md
+++ b/docs/learning/chat.vivox.md
@@ -17,8 +17,8 @@ Coreの学習を実施していない方はこの学習より先に[Coreの学�
 
 Vivoxラッパーがセットアップされた学習用のプロジェクトを使って、バーチャル空間でテキストチャットとボイスチャットをできるようにアプリケーションの実装を追加していきます。
 
-この学習を行うにはクライアントからの接続先となる[Vivox Developer Portal](https://developer.vivox.com/)のアプリケーションが必要です。
-以降のハンズオンを始める前に[Vivox Developer Portal](https://developer.vivox.com/)でアプリケーションを作成しておいてください。
+この学習を行うにはクライアントからの接続先となる[Unity Dashboard](https://dashboard.unity3d.com/vivox)のアプリケーションが必要です。
+以降のハンズオンを始める前に[Unity Dashboard](https://dashboard.unity3d.com/vivox)でアプリケーションを作成しておいてください。
 
 ## Prepare project
 

--- a/docs/learning/intro.md
+++ b/docs/learning/intro.md
@@ -122,7 +122,7 @@ Extrealを活用したアプリケーション開発を行うためには次の�
 #### Resources
 
 - Vivox Unity SDK
-  - [Vivox Developer Portal](https://developer.vivox.com/)
+  - [Vivox Unity SDK documentation](https://docs.vivox.com/v5/general/unity/15_1_220000/en-us/Default.htm)
 
 ### Asset Workflow {#asset-workflow}
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/integration/chat.vivox.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/integration/chat.vivox.md
@@ -23,13 +23,6 @@ If you do not know Vivox, please refer to [Learning](../learning/intro.md#chat) 
 This guide assumes you know Vivox.
 :::
 
-:::caution
-Vivox is available on the originally existing [Vivox Developer Portal](https://developer.vivox.com/) and [Unity Gaming Services](https://unity.com/ja/solutions/gaming-services), which appeared in October 2021.
-The current Vivox wrapper is compatible with the [Vivox Developer Portal](https://developer.vivox.com/).
-It is not compatible with [Unity Gaming Services](https://unity.com/ja/solutions/gaming-services).
-We will consider supporting [Unity Gaming Services](https://unity.com/ja/solutions/gaming-services) in the future.
-:::
-
 ## Specification
 
 The specifications of the Vivox wrapper are as follows.
@@ -147,7 +140,7 @@ Please refer to [Release](../category/release) for the correspondence between mo
 
 VivoxClient is initialized.
 
-It is assumed that the application to which the client will connect has been created in [Vivox Developer Portal](https://developer.vivox.com/).
+It is assumed that the application to which the client will connect has been created in [Unity Dashboard](https://dashboard.unity3d.com/vivox).
 
 To initialize VivoxClient, VivoxAppConfig, which holds the connection information to Vivox, is required.
 As an example, we will show how to set the connection information to Vivox with a ScriptableObject.

--- a/i18n/en/docusaurus-plugin-content-docs/current/integration/chat.vivox.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/integration/chat.vivox.md
@@ -140,7 +140,7 @@ Please refer to [Release](../category/release) for the correspondence between mo
 
 VivoxClient is initialized.
 
-It is assumed that the application to which the client will connect has been created in [Unity Dashboard](https://dashboard.unity3d.com/vivox).
+It is assumed that you have created a project with Vivox set up in [Unity Cloud](https://cloud.unity.com) to which the client will connect.
 
 To initialize VivoxClient, VivoxAppConfig, which holds the connection information to Vivox, is required.
 As an example, we will show how to set the connection information to Vivox with a ScriptableObject.

--- a/i18n/en/docusaurus-plugin-content-docs/current/learning/chat.vivox.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/learning/chat.vivox.md
@@ -17,8 +17,8 @@ If you have not learned Core, it is recommended that you learn [Learning Core](.
 
 Using the learning project with the Vivox wrapper set up, we will add an implementation of the application to allow text and voice chat in virtual space.
 
-You will need to have an application on the [Unity Dashboard](https://dashboard.unity3d.com/vivox) to connect to from the client to do this learning.
-Please create an application on the [Unity Dashboard](https://dashboard.unity3d.com/vivox) before starting the following hands-on activities.
+You will need to have a project in [Unity Cloud](https://cloud.unity.com) to connect to from the client.
+Please create a project with Vivox set up on [Unity Cloud](https://cloud.unity.com) before starting the following hands-on activities.
 
 ## Prepare project
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/learning/chat.vivox.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/learning/chat.vivox.md
@@ -17,8 +17,8 @@ If you have not learned Core, it is recommended that you learn [Learning Core](.
 
 Using the learning project with the Vivox wrapper set up, we will add an implementation of the application to allow text and voice chat in virtual space.
 
-You will need to have an application on the [Vivox Developer Portal](https://developer.vivox.com/) to connect to from the client to do this learning.
-Please create an application on the [Vivox Developer Portal](https://developer.vivox.com/) before starting the following hands-on activities.
+You will need to have an application on the [Unity Dashboard](https://dashboard.unity3d.com/vivox) to connect to from the client to do this learning.
+Please create an application on the [Unity Dashboard](https://dashboard.unity3d.com/vivox) before starting the following hands-on activities.
 
 ## Prepare project
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/learning/intro.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/learning/intro.md
@@ -122,7 +122,7 @@ The skills required, depending on the application requirements, are as follows.
 #### Resources
 
 - Vivox Unity SDK
-  - [Vivox Developer Portal](https://developer.vivox.com/)
+  - [Vivox Unity SDK documentation](https://docs.vivox.com/v5/general/unity/15_1_220000/en-us/Default.htm)
 
 ### Asset Workflow {#asset-workflow}
 


### PR DESCRIPTION
﻿# 何の変更を加えましたか？

- Vivox Developer Portalが廃止された＋Unity Gaming Services版で動作することが確認済みのため、以降の検討のcautionを削除しました。
- Vivox Developer Portalでアプリケーションを作成する部分を[Unity Cloud](https://cloud.unity.com)でプロジェクトを作成する記述に変更しました
- LearningのIntroductionのResourcesのURLを[docs.vivox.com](https://docs.vivox.com/v5/general/unity/15_1_220000/en-us/Default.htm)のものに更新しました

# 何を確認しましたか?

- [x] 変更したページと影響がありそうなページをブラウザで確認しました
- [x] 日本語と英語のページが一致していることを確認しました
- [x] リンクや画像のファイルパスは拡張子付きの相対パスになっていることを確認しました
  - [Link docs by file paths](https://docusaurus.io/docs/next/versioning#link-docs-by-file-paths)
  - [Global or versioned collocated assets](https://docusaurus.io/docs/next/versioning#global-or-versioned-collocated-assets)(using per-version)

# レビュアーへのメッセージ

- [Unity Dashboard](https://dashboard.unity3d.com)にアクセスしてもUnity Cloudにリダイレクトされ、Unity Cloudで設定を行う必要があるためUnity Cloudにしています