### PR TITLE
P2P.WebRTCの後方互換性についてReleaseページに追記

### DIFF
--- a/docs/release/unreleased.md
+++ b/docs/release/unreleased.md
@@ -4,7 +4,7 @@ sidebar_position: 1
 
 # Unreleased
 
-2024-03-29
+2024-04-04
 
 ## Unity version
 
@@ -116,6 +116,7 @@ sidebar_position: 1
 #### Changed
 - PeerConnectionのCreate/Closeでエラーが発生しても処理を継続するように変更しました。([Doc](../integration/p2p.webrtc.md), [PR](https://github.com/extreal-dev/Extreal.Integration.P2P.WebRTC/pull/9))
 - P2Pの各クライアントを識別できるように、自身及び接続または切断したクライアントのIDを取得できるように変更しました。([Doc](../integration/p2p.webrtc.md), [PR](https://github.com/extreal-dev/Extreal.Integration.P2P.WebRTC/pull/10))
+  - この変更は後方互換に影響があるため[Upgrade guide](#upgrade-guide)を参照してください。
 
 ### Extreal.Integration.SFU.OME
 #### Added
@@ -136,3 +137,13 @@ sidebar_position: 1
 ## Upgrade guide {#upgrade-guide}
 
 モジュールバージョンを更新してください。
+
+後方互換に影響がある変更があるため、下記を確認して該当するアプリケーションは対応してください。
+
+### Extreal.Integration.P2P.WebRTC
+#### 変更影響があるアプリケーション
+PeerClient.OnStartedのストリームを、Mergeなどのメソッドで結合しているアプリケーションに影響があります。
+#### 変更影響と対応方法
+- PeerClient.OnStartedの型が`IObservable<Unit>`から`IObservable<string>`に変更になりました。
+  - MergeなどのメソッドでPeerClient.OnStartedのストリームを結合している場合、型が合わなくなるためコンパイルエラーになります。
+    ストリームを結合しないようにするなど、コンパイルエラーが解消するように実装を修正してください。

--- a/docs/release/unreleased.md
+++ b/docs/release/unreleased.md
@@ -146,4 +146,4 @@ PeerClient.OnStartedのストリームを、Mergeなどのメソッドで結合�
 #### 変更影響と対応方法
 - PeerClient.OnStartedの型が`IObservable<Unit>`から`IObservable<string>`に変更になりました。
   - MergeなどのメソッドでPeerClient.OnStartedのストリームを結合している場合、型が合わなくなるためコンパイルエラーになります。
-    ストリームを結合しないようにするなど、コンパイルエラーが解消するように実装を修正してください。
+    ストリームを結合せず、Subjectメソッドを使って個別にストリームを処理してください。

--- a/i18n/en/docusaurus-plugin-content-docs/current/release/unreleased.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/release/unreleased.md
@@ -4,7 +4,7 @@ sidebar_position: 1
 
 # Unreleased
 
-2024-03-29
+2024-04-04
 
 ## Unity version
 
@@ -116,6 +116,7 @@ The following Unity versions have been tested.
 #### Changed
 - Changed to continue processing even if errors occur in Create/Close of PeerConnection. ([Doc](../integration/p2p.webrtc.md), [PR](https://github.com/extreal-dev/Extreal.Integration.P2P.WebRTC/pull/9))
 - Changed so that the ID of your own client and connected or disconnected clients can be obtained, so that each P2P client can be identified. ([Doc](../integration/p2p.webrtc.md), [PR](https://github.com/extreal-dev/Extreal.Integration.P2P.WebRTC/pull/10))
+  - Please refer to the [Upgrade guide](#upgrade-guide) as this change affects backward compatibility.
 
 ### Extreal.Integration.SFU.OME
 #### Added
@@ -136,3 +137,13 @@ The following Unity versions have been tested.
 ## Upgrade guide {#upgrade-guide}
 
 Please update the module versions.
+
+Since there are changes that affect backward compatibility, please check the following and respond to the applicable applications.
+
+### Extreal.Integration.P2P.WebRTC
+#### Applications affected by the change
+Applications that combine PeerClient.OnStarted streams using methods such as Merge are affected.
+#### Change impact and how to respond
+- The type of PeerClient.OnStarted has been changed from `IObservable<Unit>` to `IObservable<string>`.
+  - If you combine PeerClient.OnStarted streams using a method such as Merge, the types will no longer match and a compilation error will occur.
+    Please modify the implementation to resolve the compilation error, such as by not combining streams.

--- a/i18n/en/docusaurus-plugin-content-docs/current/release/unreleased.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/release/unreleased.md
@@ -146,4 +146,4 @@ Applications that combine PeerClient.OnStarted streams using methods such as Mer
 #### Change impact and how to respond
 - The type of PeerClient.OnStarted has been changed from `IObservable<Unit>` to `IObservable<string>`.
   - If you combine PeerClient.OnStarted streams using a method such as Merge, the types will no longer match and a compilation error will occur.
-    Please modify the implementation to resolve the compilation error, such as by not combining streams.
+    Please do not combine streams and use the Subject method to process streams individually.


### PR DESCRIPTION
﻿# 何の変更を加えましたか？

- P2P.WebRTCの後方互換性が、PeerClient.OnStartedのストリームをMergeなどのメソッドで結合している場合に保たれないため、Releaseページに変更影響と対応方法を追記しました。

# 何を確認しましたか?

- [x] 変更したページと影響がありそうなページをブラウザで確認しました
- [x] 日本語と英語のページが一致していることを確認しました
- [x] リンクや画像のファイルパスは拡張子付きの相対パスになっていることを確認しました
  - [Link docs by file paths](https://docusaurus.io/docs/next/versioning#link-docs-by-file-paths)
  - [Global or versioned collocated assets](https://docusaurus.io/docs/next/versioning#global-or-versioned-collocated-assets)(using per-version)

# レビュアーへのメッセージ
