### PR TITLE
Multiplay.Messaging の Newtonsoft.Json への参照方法の変更

### DIFF
--- a/docs/integration/multiplay.messaging.md
+++ b/docs/integration/multiplay.messaging.md
@@ -112,6 +112,7 @@ https://github.com/extreal-dev/Extreal.Integration.Multiplay.Messaging.git
 - [Extreal.Integration.Messaging](messaging.md)
 - [UniTask](https://github.com/Cysharp/UniTask)
 - [UniRx](https://github.com/neuecc/UniRx)
+- [Newtonsoft Json](https://docs.unity3d.com/Packages/com.unity.nuget.newtonsoft-json@3.2/manual/index.html)
 
 モジュールバージョンと各パッケージバージョンの対応は[Release](../../category/release)を参照ください。
 

--- a/docs/release/unreleased.md
+++ b/docs/release/unreleased.md
@@ -52,6 +52,8 @@ sidebar_position: 1
 - Extreal.Integration.Messaging.Socket.IO
   - [System.Text.Json](https://learn.microsoft.com/ja-jp/dotnet/api/system.text.json) 7.0.3 ([MIT License](https://github.com/dotnet/runtime/blob/main/LICENSE.TXT))
   - [SocketIOClient](https://github.com/doghappy/socket.io-client-csharp) 3.0.8 ([MIT License](https://github.com/doghappy/socket.io-client-csharp/blob/master/LICENSE))
+- Extreal.Integration.Multiplay.Messaging
+  - [Newtonsoft Json](https://docs.unity3d.com/Packages/com.unity.nuget.newtonsoft-json@3.2/manual/index.html) 3.2.1 ([Unity Companion License](https://docs.unity3d.com/Packages/com.unity.nuget.newtonsoft-json@3.2/license/LICENSE.html))
 - Extreal.Integration.Multiplay.NGO
   - [Netcode for GameObjects](https://github.com/Unity-Technologies/com.unity.netcode.gameobjects) 1.7.1 ([MIT License](https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/blob/develop/LICENSE.md))
 - Extreal.Integration.Multiplay.NGO.WebRTC

--- a/i18n/en/docusaurus-plugin-content-docs/current/integration/multiplay.messaging.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/integration/multiplay.messaging.md
@@ -112,6 +112,7 @@ This module uses the following packages.
 - [Extreal.Integration.Messaging](./messaging.md)
 - [UniTask](https://github.com/Cysharp/UniTask)
 - [UniRx](https://github.com/neuecc/UniRx)
+- [Newtonsoft Json](https://docs.unity3d.com/Packages/com.unity.nuget.newtonsoft-json@3.2/manual/index.html)
 
 Please refer to [Release](../../category/release) for the correspondence between module version and each package version.
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/release/unreleased.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/release/unreleased.md
@@ -52,6 +52,8 @@ The following Unity versions have been tested.
 - Extreal.Integration.Messaging.Socket.IO
   - [System.Text.Json](https://learn.microsoft.com/ja-jp/dotnet/api/system.text.json) 7.0.3 ([MIT License](https://github.com/dotnet/runtime/blob/main/LICENSE.TXT))
   - [SocketIOClient](https://github.com/doghappy/socket.io-client-csharp) 3.0.8 ([MIT License](https://github.com/doghappy/socket.io-client-csharp/blob/master/LICENSE))
+- Extreal.Integration.Multiplay.Messaging
+  - [Newtonsoft Json](https://docs.unity3d.com/Packages/com.unity.nuget.newtonsoft-json@3.2/manual/index.html) 3.2.1 ([Unity Companion License](https://docs.unity3d.com/Packages/com.unity.nuget.newtonsoft-json@3.2/license/LICENSE.html))
 - Extreal.Integration.Multiplay.NGO
   - [Netcode for GameObjects](https://github.com/Unity-Technologies/com.unity.netcode.gameobjects) 1.7.1 ([MIT License](https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/blob/develop/LICENSE.md))
 - Extreal.Integration.Multiplay.NGO.WebRTC


### PR DESCRIPTION
﻿# 何の変更を加えましたか？

- Multiplay.Messaging の Newtonsoft.Json への参照方法を変更しました

# 何を確認しましたか?

- [x] 変更したページと影響がありそうなページをブラウザで確認しました
- [x] 日本語と英語のページが一致していることを確認しました
- [x] リンクや画像のファイルパスは拡張子付きの相対パスになっていることを確認しました
  - [Link docs by file paths](https://docusaurus.io/docs/next/versioning#link-docs-by-file-paths)
  - [Global or versioned collocated assets](https://docusaurus.io/docs/next/versioning#global-or-versioned-collocated-assets)(using per-version)
- [x] categoryページ(category/release等)への相対リンクが現在のバージョンのページに遷移することを確認しました

# レビュアーへのメッセージ
